### PR TITLE
clone is not a function, but a keyword, and so do not need calling paren...

### DIFF
--- a/src/debug.php
+++ b/src/debug.php
@@ -144,7 +144,7 @@ class ezcDebug
 
         $original = ezcLog::getInstance();
 
-        $this->log = clone( $original ); 
+        $this->log = clone $original; 
         $this->log->reset();
         $this->log->setMapper( new ezcLogFilterSet() );
 


### PR DESCRIPTION
...thesis
